### PR TITLE
change sort order of cached messages

### DIFF
--- a/snews/storage.py
+++ b/snews/storage.py
@@ -70,14 +70,14 @@ class MongoStorage(IStorage):
 
     def getAllMessages(self):
         """
-        sort by 1 gives dates from old to recent
-        sort by 2 gives dates from recent to old
+        sort by pymongo.ASCENDING (1) gives dates from old to recent
+        sort by pymongo.DESCENDING (-1) gives dates from recent to old
         :return:
         """
         return self.all_messages.find().sort("sent_time", -1)
 
-    def getCacheMsgs(self):
-        return self.cache.find().sort("sent_time", -1)
+    def getCacheMsgs(self, sort_order=pymongo.ASCENDING):
+        return self.cache.find().sort("sent_time", sort_order)
 
     def cacheEmpty(self):
         return self.cache.count() <= 1


### PR DESCRIPTION
## Description

`Decider.deciding` incorrectly returned `True` even if two consecutive observations are more than the coincidence threshold apart. This is because `MongoStorage.getCacheMsgs` returned cached messages as a list with newest messages first, while `Decider.deciding` expected oldest messages first.

This PR fixes that by adding an optional `sort_order` argument in `getCacheMsgs`, which defaults to `pymongo.ASCENDING` (instead of hard-coding it to -1, which corresponded to descending).

## Checklist

* [ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] Add/update sphinx documentation with any relevant changes.
* [ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [ ] `make lint` doesn't give any warnings.
* [ ] `make format` doesn't give any code formatting suggestions.
* [ ] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
