### PR TITLE
Fix/makefile ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ test :
 .PHONY: lint
 lint :
 	# stop the build if there are Python syntax errors or undefined names
-	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	flake8 snews tests setup.py --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings
-	flake8 . --count --exit-zero --max-complexity=12 --max-line-length=100 --statistics
+	flake8 snews tests setup.py --count --exit-zero --max-complexity=12 --max-line-length=100 --statistics
 
 .PHONY: format
 format :
-	autopep8 --recursive --in-place .
+	autopep8 --recursive --in-place snews tests setup.py
 
 .PHONY: doc
 doc :

--- a/doc/api/decider.rst
+++ b/doc/api/decider.rst
@@ -1,7 +1,7 @@
 .. _decider:
 
-snews.IDecider
+snews.decider
 #####################
 
-.. automodule:: snews.IDecider
+.. automodule:: snews.decider
     :members:

--- a/doc/api/storage.rst
+++ b/doc/api/storage.rst
@@ -1,7 +1,7 @@
 .. _IStorage:
 
-snews.IStorage
+snews.storage
 #####################
 
-.. automodule:: snews.IStorage
+.. automodule:: snews.storage
     :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,7 +96,7 @@ html_theme = 'default'
 
 
 def setup(app):
-    app.add_stylesheet('css/my_theme.css')
+    app.add_css_file('css/my_theme.css')
 
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ User's Guide
    user/quickstart
    user/architecture
    user/messages
-   user/protocols
+   user/protocol
 
 API Reference
 -------------

--- a/tests/test.py
+++ b/tests/test.py
@@ -262,7 +262,8 @@ class latencyTest(object):
         msg_id = msg_dict["header"]["MESSAGE ID"]
         receivedTime = datetime.datetime.utcnow().strftime(os.getenv("TIME_STRING_FORMAT"))
         sentTime = msg_dict['header']['MESSAGE SENT TIME']
-        timeDiff = datetime.datetime.strptime(receivedTime, os.getenv("TIME_STRING_FORMAT")) - datetime.datetime.strptime(sentTime, os.getenv("TIME_STRING_FORMAT"))
+        timeDiff = datetime.datetime.strptime(receivedTime, os.getenv(
+            "TIME_STRING_FORMAT")) - datetime.datetime.strptime(sentTime, os.getenv("TIME_STRING_FORMAT"))
         timeDiff_inSeconds = timeDiff.total_seconds()
         # print("HERE")
         with self.lock:


### PR DESCRIPTION
## Description

This PR addresses the issues encountered when running `make` checklist entries for new PRs, as mentioned in #22. The problem was that the `make` commands would go through all files in the current working directory (not just the SNEWS codebase and tests), so other files would be parsed and could cause red herring errors or hanging loops.

After addressing those issues, running the `make doc` check succeeds with the following issues/warnings:
```
# make doc
...
WARNING: autodoc: failed to import module 'IDecider' from module 'snews'; the following exception was raised:
No module named 'snews.IDecider'
/home/bfc5288/git.hub/scimma/hop-SNalert-app/doc/api/decider.rst:4: WARNING: duplicate label decider, other instance in /home/bfc5288/git.hub/scimma/hop-SNalert-app/doc/user/architecture.rst
WARNING: autodoc: failed to import module 'IStorage' from module 'snews'; the following exception was raised:
No module named 'snews.IStorage'
/home/bfc5288/git.hub/scimma/hop-SNalert-app/doc/index.rst:7: WARNING: toctree contains reference to nonexisting document 'user/protocols'
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/bfc5288/git.hub/scimma/hop-SNalert-app/doc/user/protocol.rst: WARNING: document isn't included in any toctree
...
```
This caused the `snews.decider` and `snews.storage` html doc files to not generate, and `protocol` was omitted due to a typo (see the [old docs here](https://web.archive.org/web/20210616175647/https://hop-snalert-app.readthedocs.io/en/stable/api/api.html)).

This PR fixes these issues, resolving the empty Decider and Storage entries in the API docs and the missing Protocol doc entry.


## Checklist

* [ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] Add/update sphinx documentation with any relevant changes.
* [ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
