### PR TITLE
Improved usage of GitHub Actions; fix Decider test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build
@@ -20,8 +20,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
     - name: Test
-      run: |
-        make test
+      run: make test
     - name: Lint
       if: ${{ matrix.python-version == '3.9' }}
       run: make lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           # All of these options are optional, so you can remove them if you are happy with the defaults
-          concurrent_skipping: 'same_content'
+          concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
           # do_not_skip: '["pull_request"]'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,13 @@
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
-
+  build-and-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,16 @@ jobs:
     - name: Build
       run: |
         python -m pip install --upgrade pip
-        pip install .
-    - name: Lint
-      run: |
         pip install .[dev]
-        make lint
     - name: Test
       run: |
-        pip install .[dev]
         make test
+    - name: Lint
+      if: ${{ matrix.python-version == '3.9' }}
+      run: make lint
+    - name: Format
+      if: ${{ matrix.python-version == '3.9' }}
+      run: make format
+    - name: Docs
+      if: ${{ matrix.python-version == '3.9' }}
+      run: make doc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,24 @@ name: build
 on: [push, pull_request]
 
 jobs:
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          # do_not_skip: '["pull_request"]'
+
   build-and-test:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,6 @@ jobs:
       run: make format
     - name: Docs
       if: ${{ matrix.python-version == '3.9' }}
-      run: make doc
+      run: |
+        pip install .[docs]
+        make doc

--- a/tests/fixtures/cache.yaml
+++ b/tests/fixtures/cache.yaml
@@ -13,7 +13,7 @@
   sent_time: !!timestamp '2020-09-23 13:47:13'
   neutrino_time: !!timestamp '2020-09-23 13:47:13'
   machine_time: '20/09/23 13:47:13'
-  location: 'Austin'
+  location: 'San Diego'
   p_value: 0.5
   status: 'On'
   content: 'For testing'


### PR DESCRIPTION
## Description

* adds more recent Python version to test matrix
* adds `make doc` and `make format` as suggested in #23 
* run `make lint` only on most recent Python version (since we don’t expect linting to vary between Python versions)

Note that `make doc` [currently fails](https://github.com/SNEWS2/hop-SNalert-app/runs/2842896212?check_suite_focus=true). Help wanted on solving that! (Note also that this failure only affects the test under Python 3.9, since `make doc` (like `make lint`) is skipped under older Python versions.)

## Checklist

* ~[ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* ~[ ] Add/update sphinx documentation with any relevant changes.~
* ~[ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.~
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
